### PR TITLE
fix(docs): custom converter example

### DIFF
--- a/docs/blog/2019-12-11-reducing-interaction-cloud/index.md
+++ b/docs/blog/2019-12-11-reducing-interaction-cloud/index.md
@@ -5,80 +5,92 @@ author: Shannon Soper
 tags: ["ux", "cloud"]
 ---
 
-In my last blogpost, I introduced how we’re [making it easier to start with Gatsby Cloud for 
+In my last blogpost, I introduced how we’re [making it easier to start with Gatsby Cloud for
 free](https://www.gatsbyjs.org/blog/2019-11-25-getting-started-with-gatsby-cloud/) with starters. This blogpost introduces the next set of changes that we shipped to help users get started faster. How did we do it? Inferring from history to reduce unnecessary user interaction. Quite a mouthful and needs some explanation.
 
 ## The problem
+
 So what problem did we learn about?
 
-When watching folks onboard onto Gatsby Cloud, there was a clear point of confusion. Please see the screenshot below and read the thought bubble which depicts *approximately* what users said during usability tests.
- 
+When watching folks onboard onto Gatsby Cloud, there was a clear point of confusion. Please see the screenshot below and read the thought bubble which depicts _approximately_ what users said during usability tests.
+
 ![This screenshot depicts step two of Gatsby Cloud onboarding, during which users select an organization from GitHub. I drew a speech bubble on top of the screenshot pointing out that users are confused by this screen. The speech bubble says: “Wait, I don't want to create a repository in my work's GitHub organization. Terminate mission!"](select-work-org-confusion.png)
 
 ## What was the real problem?
+
 We knew users were confused, yet we didn’t know how to solve it quite yet. Here are some principles that helped us figure out the reason for the confusion and how to resolve it.
 
 ## Interaction is negative
 
-I know, I know, this is a bit of a purposefully inflammatory and misleading statement. Interaction design is something I care about and do full-time along with many of you, so why would I say it’s negative? Well, the real phrase ought to read “_unnecessary_ interaction is negative.” So anything software can do to [*reduce* the amount of unnecessary interaction](http://worrydream.com/MagicInk/#p145) it takes to reach a goal is good.
+I know, I know, this is a bit of a purposefully inflammatory and misleading statement. Interaction design is something I care about and do full-time along with many of you, so why would I say it’s negative? Well, the real phrase ought to read “_unnecessary_ interaction is negative.” So anything software can do to [_reduce_ the amount of unnecessary interaction](http://worrydream.com/MagicInk/#p145) it takes to reach a goal is good.
 
 So how do you reduce unnecessary interaction?
 
 ## Reduce interaction by inferring from history and the environment
+
 To reduce interaction, you can infer “as much as possible from history and the environment.” See this full quote below:
 
 <Pullquote>If the software properly infers as much as possible from history and the environment, it should be able to produce at least a reasonable starting point for the context model. Most of the user’s interaction will then consist of correcting (or confirming) the software’s predictions. This is generally less stressful than constructing the entire context from scratch.</Pullquote>
 
 _Quote from Brett Victor, [“Magic Ink”](http://worrydream.com/MagicInk/#p173)_
 
-The principle is to make the best guess we can of what the user wants and then let them *correct* our best guess if it’s wrong. And the guess will be right most of the time, if we infer from history and the environment.
+The principle is to make the best guess we can of what the user wants and then let them _correct_ our best guess if it’s wrong. And the guess will be right most of the time, if we infer from history and the environment.
 
 So what could we infer from “history” and the “environment” to solve the problem we had in Gatsby Cloud, where everyone was confused and frustrated at needing to choose a GitHub organization?
 
 ## Inferring from history
+
 The first step is simply to look at history; I’ll take you on a tour of what happened before users hit their point of confusion.
 
 ### User selects starter
+
 In this first screenshot, the user selects a starter.
 ![Screenshot of the starter page](final-state.png)
 
 ### User logs into GitHub and into Gatsby Cloud
+
 Next, the user logs into GitHub and give Gatsby Cloud permission to connect with their personal GitHub account.
 ![Screenshot of the Gatsby Cloud login page with a thought bubble the author drew on top of the screenshot. The thought bubble contains the text “Alright, I can sign in with Git Hub. I have an account!”](cloud-login-400.png)
 
 ### Unecessary interaction: user adds new GitHub organization
+
 Then, this screen asks them to “add new organization.” This is where the software failed to learn from recent history. The user just gave the system access to their personal GitHub account, so that the last value they gave the system and we ought to stick with that value.
 
 ![Screenshot of the landing page for first-time visitors who have logged into Gatsby Cloud with a thought bubble the author drew on top of the screenshot. The thought bubble contains the text “What organization? GitHub organization? If so, why would I need to connect to GitHub again?” and "Gatsby Cloud, you have left me with no choice...I must click this button" referring to the "Add New Organization" button](add-new-org-confusion.png)
 
 By the time the user adds an organization (and they don’t know why they have to add it), and sees this next screen below, of course they are confused about why they added an organization. They didn’t need to!
- 
+
 ![screenshot of step two of Gatsby Cloud onboarding, during which users select an organization from GitHub. I drew a speech bubble on top of the screenshot pointing out that users are confused by this screen. The speech bubble says: “Wait, I don't want to create a repository in my work's GitHub organization. Terminate mission!”](select-work-org-confusion.png)
 
 ## Reducing interaction
-To reduce interaction by inferring from history, we assume the user wants to save their first site in their GitHub personal account, the last value they provided us with when they logged in. They can *correct* this assumption if it’s wrong.
+
+To reduce interaction by inferring from history, we assume the user wants to save their first site in their GitHub personal account, the last value they provided us with when they logged in. They can _correct_ this assumption if it’s wrong.
 
 ### First-time visitor
-The assumption that user wants to save their first site in their personal GitHub account is reflected in the following GIF that shows the user does *not have to interact with the software to tell us where to save their site*, though they *can correct the default (their personal GitHub account) if it’s wrong*.
+
+The assumption that user wants to save their first site in their personal GitHub account is reflected in the following GIF that shows the user does _not have to interact with the software to tell us where to save their site_, though they _can correct the default (their personal GitHub account) if it’s wrong_.
 
 ![A GIF depicting a screen in which the user names their site and clicks “Next." There is text on the screen that reads: “we’ll create the repo under your personal GitHub account. Want to host it on a GitHub organization instead? Add it here!”](create-new-site.gif)
 
 ### Returning user
-If there is a returning user that has already connected their personal account plus at least one more organization, their personal account will be the first item in a list and will always be pre-selected. This makes sure that, again, they *do not have to interact with the software* except to correct it, if it’s wrong. 
+
+If there is a returning user that has already connected their personal account plus at least one more organization, their personal account will be the first item in a list and will always be pre-selected. This makes sure that, again, they _do not have to interact with the software_ except to correct it, if it’s wrong.
 
 ![This GIF depicts the screen in which the user names their site and their personal account is at the top of a list of GitHub organizations and is pre-selected as the destination for the site.](return-visitor.gif)
 
 ## What's next?
+
 Stay tuned for more blogposts about why we:
+
 - Added a free pricing tier, which lets you use Gatsby Cloud for free for blogs, portfolios, etc.
 - Made it easy to connect existing sites to Cloud
 - Shipped Gatsby Preview
-- Offer customized assessments of your builds, including Lighthouse scores 
+- Offer customized assessments of your builds, including Lighthouse scores
 
 As a design team, we'll also keep blogging about what we’re working on. This includes:
+
 - Transferring the principle of inferring from history so users choosing "I already have an existing Gatsby site" get the benefits of that principle as well
 - Adding more starters, including MDX, to do some of the work for you
 - Adding more integrations to do some work for you
 - Easy-to-read error messages that help you debug
 - More customized assessments of your builds, including performance budgets, structured logging, etc.
-

--- a/docs/contributing/triaging-github-issues.md
+++ b/docs/contributing/triaging-github-issues.md
@@ -16,7 +16,7 @@ For Gatsby the first line of communication between a user and the team is the is
 
 An opened issue could be:
 
-- a question that can be answered immediately
+- [a question that can be answered immediately](#questions-with-immediate-answers)
 - a bug report
 - a request for a feature
 - or a discussion on a complicated use case
@@ -25,7 +25,7 @@ On the core team, we regularly designate someone to be a first touch maintainer.
 
 First touch maintainers will typically:
 
-- answer questions that can be answered immediately
+- [answer questions by pointing to documentation](#questions-with-immediate-answers)
 - test and reproduce possible bug reports and label them appropriately
 - communicate feature requests to the rest of the team and ensure a valid response
 - enable discussions on complicated use cases, whether themselves or via the rest of team
@@ -62,6 +62,18 @@ Labeling helps group issues into manageable sets and also improves searchability
 It's nice to update labels as the state of an issue changes or if the type of an issue changes, for example if a question becomes a feature request. This means labels are transient in nature and subject to being updated as progress is made on addressing issues.
 
 Check out [the docs on issue labeling for more info](/contributing/how-to-label-an-issue/)
+
+### Questions with immediate answers
+
+- Point to existing documentation to answer the question
+- If insufficient, do the following:
+  1. Provide an answer
+  2. Label the issue with documentation
+  3. Keep it open until a PR has added the answer to the documentation, and the issue includes a link to said documentation
+
+If an issue comes in as a question with a known answer it can be tempting to answer it and close the issue. However, the consequence of this approach is that the answer to a question others may have is now buried in a closed issue and may be hard to surface. The preferred solution is to get that answer documented in the main Gatsby documentation and connect the issue to an answer by including a docs link.
+
+When a question comes in and it is determined to have a known answer, find the existing documentation that explains it. If that documentation does not exist, is insufficient, or unclear, it is reasonable to provide an answer in a comment in the issue. However, the issue should remain open and be labled as documentation. If you are able, you can open a PR adding the provided answer to the official documentation.
 
 ### Resolution flowchart
 

--- a/docs/docs/eslint.md
+++ b/docs/docs/eslint.md
@@ -38,10 +38,8 @@ module.exports = {
 }
 ```
 
+Note: When there is no ESLint file Gatsby implicitly adds a barebones ESLint loader. This loader pipes ESLint feedback into the terminal window where you are running or building Gatsby and also to the console in your browser developer tools. This gives you consolidated, immediate feedback on newly-saved files. When you include a custom `.eslintrc` file, Gatsby gives you full control over the ESLint configuration. This means that it will override the built-in `eslint-loader` and you need to enable any and all rules yourself. One way to do this is to use the Community plugin [`gatsby-eslint-plugin`](/packages/gatsby-plugin-eslint/). This also means that the default [ESLint config Gatsby ships with](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/eslint-config.js) will be entirely overwritten. If you would still like to take advantage of those rules, you'll need to copy them to your local file.
+
 ### Disabling ESLint
 
-Create an empty .eslintrc.js file at the root of your project to disable linting.
-
-When there is no ESLint file Gatsby implicitly adds a barebones ESLint loader. The empty file will disable this behavior as Gatsby assumes once you have an ESLint file you are in charge of linting.
-
-Note: If you provide a custom `.eslintrc.js` file, Gatsby gives you full control about the ESLint configuration. This means that it will disable the built-in `eslint-loader` and you need to enable it yourself. One way to do so is to use the Community plugin [`gatsby-eslint-plugin`](/packages/gatsby-plugin-eslint/).
+Creating an empty `.eslintrc` file at the root of your project will disable ESLint for your site. The empty file will disable the built-in `eslint-loader` because Gatsby assumes once you have an ESLint file you are in charge of linting.

--- a/docs/docs/making-your-site-accessible.md
+++ b/docs/docs/making-your-site-accessible.md
@@ -35,21 +35,23 @@ For websites, rendering [static HTML](/docs/glossary#static) pages means that Ja
 
 ### Linting with eslint-jsx-plugin-a11y
 
-Gatsby ships with `eslint-config-react-app` by default, which includes the `eslint-jsx-plugin-a11y` package. [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) is an accessibility [linting](/docs/glossary#linting) tool for your code, helping you develop more inclusive Gatsby projects. This plugin encourages you to include alternative text for image tags, validates [ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) props, and eliminates redundant role properties, among other things. It's a start to testing for accessibility: [further recommendations](#how-to-improve-accessibility) can be found below.
+Gatsby ships with the `eslint-jsx-plugin-a11y` package and warnings for all of its rules enabled by default. [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) is an accessibility [linting](/docs/glossary#linting) tool for your code, helping you develop more inclusive Gatsby projects by reducing the time to find accessibility errors. This plugin encourages you to include alternative text for image tags, validates [ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) props, and eliminates redundant role properties, among other things.
 
-Including this plugin and its [recommended rule set](https://github.com/facebook/create-react-app/tree/master/packages/eslint-config-react-app#accessibility-checks) reduces the time required to implement accessibility by reminding you throughout development. The rules enabled in `eslint-plugin-jsx-a11y` by default can be [customized in `.eslintrc`](/docs/eslint/#configuring-eslint).
+For more on supported rules, check out the docs for [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y). You can customize those rules in your [`.eslintrc`](/docs/eslint/#configuring-eslint).
 
 ```json:title=.eslintrc
 {
   "extends": ["react-app", "plugin:jsx-a11y/recommended"],
   "plugins": ["jsx-a11y"],
   "rules": {
-    "jsx-a11y/rule-name": 2
+    "jsx-a11y/rule-name": "warning"
   }
 }
 ```
 
-For more on supported rules, check out the docs for [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y).
+Note: Including a local `.eslintrc` file will [override](/docs/eslint/#configuring-eslint) all of Gatsby's default linting and disable the built-in `eslint-loader`, meaning your tweaked rules won't make it to your browser's developer console or your terminal window but will still be displayed if you have ESLint plugins enabled in your IDE. If you would like to change this behavior and make sure the `eslint-loader` pulls in your customizations, you'll need to enable the loader yourself. One way to do this is by using the Community plugin [`gatsby-plugin-eslint`](https://www.gatsbyjs.org/packages/gatsby-plugin-eslint/). Additionally, if you would still like to take advantage of some subset of the default [ESLint config Gatsby ships with](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/eslint-config.js), you'll need to copy them manually to your local `.eslintrc` file.
+
+This is a start to testing for accessibility: [further recommendations](#how-to-improve-accessibility) can be found below.
 
 ## How to improve accessibility?
 

--- a/docs/docs/plugins-themes-and-starters.md
+++ b/docs/docs/plugins-themes-and-starters.md
@@ -1,0 +1,38 @@
+---
+title: Plugins, Themes, & Starters
+overview: true
+---
+
+In the Gatsby ecosystem, there's more than one way to build a site. To help you understand the differences between plugins, themes, and starters, this guide will talk through some of the details.
+
+## What is a plugin?
+
+Gatsby plugins are Node.js packages that implement Gatsby APIs and are commonly installed through a registry like npm. There are many types of [plugins](/plugins/), including data sourcing, SEO, responsive images, offline support, support for Sass, TypeScript, sitemaps and RSS, Google Analytics, and more. You can also [make your own plugins](/docs/creating-plugins/) and either distribute them for fellow Gatsby developers to use or [install them locally](/docs/loading-plugins-from-your-local-plugins-folder/).
+
+- [Plugin docs](/docs/plugins/)
+- [Using a plugin](/docs/using-a-plugin-in-your-site/)
+- [Plugin library](/plugins/)
+- [Creating plugins](/docs/creating-plugins/)
+
+## What is a theme?
+
+A Gatsby theme is a type of plugin that includes a `gatsby-config.js` file and adds pre-configured functionality, data sourcing, and/or UI code to Gatsby sites. Since they are plugins, themes can be packaged and distributed through a registry like npm or yarn, and versions can be updated through a site's `package.json` file.
+
+With a Gatsby theme, all of your default configuration (shared functionality, data sourcing, design) is abstracted out of your site and into an installable package. A theme might differ from a typical plugin in that it packages up usage of a plugin into a consumable API, making it easy to include functionality without having to type out all of the code by hand (such as GraphQL queries). To understand more of the motivation for Gatsby themes, check out the docs on [What are Gatsby Themes?](/docs/themes/what-are-gatsby-themes/)
+
+- [Themes docs](/docs/themes/)
+- [Using a theme](/docs/themes/using-a-gatsby-theme/)
+- [Themes in plugin library](/plugins/?=gatsby-theme)
+- [Creating a theme](/docs/themes/building-themes/)
+
+## What is a starter?
+
+A starter is a boilerplate Gatsby site that users can copy and [customize](/docs/modifying-a-starter/). Once modified, a starter maintains no connection to its source.
+
+Gatsby offers [official starters](/docs/starters/#official-starters) for a default site, blog site, bare-bones hello world site, and both using and creating themes. There are also many starters from members of the community that can provide a good starting point for your Gatsby site.
+
+- [Starter docs](/docs/starters/)
+- [Modifying a starter](/docs/modifying-a-starter/)
+- [Starter library](/starters/)
+- [Creating a starter](/docs/creating-a-starter/)
+- [Converting a starter to a theme](/docs/themes/converting-a-starter/)

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -4,6 +4,10 @@ title: Plugins
 
 Gatsby plugins are Node.js packages that implement Gatsby APIs. For larger, more complex sites, plugins let you modularize your site customizations into site-specific plugins.
 
-Here are the guides in this section of the docs:
+There are many types of Gatsby plugins, including data sourcing, SEO, responsive images, offline support, Sass support, sitemaps, RSS feeds, TypeScript, Google Analytics, and more. You can also [make your own plugins](/docs/creating-plugins/)!
+
+Gatsby themes are a type of plugin that include a `gatsby-config.js` file and add **pre-configured** functionality, data sourcing, and/or UI code to Gatsby sites. To learn more about theme use cases and APIs, check out the [themes section of the docs](/docs/themes/).
+
+Here are the guides in the Plugins section of the docs:
 
 <GuideList slug={props.slug} />

--- a/docs/docs/starters.md
+++ b/docs/docs/starters.md
@@ -62,11 +62,13 @@ gatsby new blog ./Code/my-local-starter
 
 Official starters are maintained by Gatsby.
 
-| Starter                                                                              | Demo                                                         | Use case                       | Features                     |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------ | ---------------------------- |
-| [gatsby-starter-default](https://github.com/gatsbyjs/gatsby-starter-default)         | [Demo](https://gatsby-starter-default-demo.netlify.com/)     | Appropriate for most use cases | General Gatsby site          |
-| [gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog)               | [Demo](https://gatsby-starter-blog-demo.netlify.com/)        | Create a basic blog            | Blog post pages and listings |
-| [gatsby-starter-hello-world](https://github.com/gatsbyjs/gatsby-starter-hello-world) | [Demo](https://gatsby-starter-hello-world-demo.netlify.com/) | Learn Gatsby                   | Gatsby bare essentials       |
+| Starter                                                                                      | Demo/Docs                                                    | Use case                       | Features                     |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------ | ---------------------------- |
+| [gatsby-starter-default](https://github.com/gatsbyjs/gatsby-starter-default)                 | [Demo](https://gatsby-starter-default-demo.netlify.com/)     | Appropriate for most use cases | General Gatsby site          |
+| [gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog)                       | [Demo](https://gatsby-starter-blog-demo.netlify.com/)        | Create a basic blog            | Blog post pages and listings |
+| [gatsby-starter-hello-world](https://github.com/gatsbyjs/gatsby-starter-hello-world)         | [Demo](https://gatsby-starter-hello-world-demo.netlify.com/) | Learn Gatsby                   | Gatsby bare essentials       |
+| [gatsby-starter-blog-theme](https://github.com/gatsbyjs/gatsby-starter-blog-theme)           | [Docs](/docs/themes/getting-started/)                        | Blog posts and pages           | Gatsby themes                |
+| [gatsby-starter-theme-workspace](https://github.com/gatsbyjs/gatsby-starter-theme-workspace) | [Docs](/docs/themes/building-themes/)                        | Building Gatsby Themes         | Minimal theme workspace      |
 
 ## Modifying starters
 

--- a/docs/docs/themes.md
+++ b/docs/docs/themes.md
@@ -19,3 +19,4 @@ This means that the configuration and functionality isn’t directly written int
 
 - [Gatsby theme tutorials](/tutorial/theme-tutorials/)
 - [Gatsby blog posts on themes](/blog/tags/themes)
+- [Plugins, Themes, and Starters](/docs/plugins-themes-and-starters/)

--- a/docs/docs/themes/converting-a-starter.md
+++ b/docs/docs/themes/converting-a-starter.md
@@ -2,7 +2,15 @@
 title: Converting a Starter to a Theme
 ---
 
-Gatsby themes are designed to be easy to create from an existing starter. Here we will walk you through the main steps of converting your starter to a theme.
+Gatsby themes are designed to be easy to create from an existing starter. This guide will walk you through the main steps of converting your starter to a theme.
+
+## What is a starter? What is a theme?
+
+A starter is a boilerplate Gatsby site that users can copy and [customize](/docs/modifying-a-starter/). Once modified, a starter maintains no connection to its source.
+
+A theme is a type of plugin that includes a `gatsby-config.js` file and adds pre-configured functionality, data sourcing, and/or UI code to Gatsby sites. In contrast to starters, themes can be packaged and distributed through a registry like npm, and their versions can be tracked/managed through a `package.json` file.
+
+One reason to convert a starter to a theme is to make it easier to push updates out to consumers of your code. With a starter, users would have to try and update their code from the original starter repo and run the risk of overwriting some of their own changes. With a theme, it's much easier for developers to update code through their package manager and rely on a consistent theme API that respects their customizations.
 
 ## Prepare Your `package.json`
 

--- a/packages/gatsby-transformer-asciidoc/README.md
+++ b/packages/gatsby-transformer-asciidoc/README.md
@@ -175,7 +175,7 @@ plugins: [
 In the example below, we will use a custom converter to convert paragraphs but the other nodes will be converted using the built-in HTML5 converter:
 
 ```javascript
-const asciidoc = require(`asciidoctor.js`)()
+const asciidoc = require(`asciidoctor`)()
 
 class TemplateConverter {
   constructor() {

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -240,15 +240,6 @@
                   link: /docs/remark-plugin-tutorial/
                 - title: Maintaining a Plugin*
                   link: /docs/maintaining-a-plugin/
-        - title: Starters
-          link: /docs/starters/
-          items:
-            - title: Starter Library
-              link: /starters/
-            - title: Modifying a Starter
-              link: /docs/modifying-a-starter/
-            - title: Creating a Starter
-              link: /docs/creating-a-starter/
         - title: Themes
           link: /docs/themes/
           items:
@@ -270,6 +261,15 @@
               link: /docs/themes/theme-composition/
             - title: Conventions
               link: /docs/themes/conventions/
+        - title: Starters
+          link: /docs/starters/
+          items:
+            - title: Starter Library
+              link: /starters/
+            - title: Modifying a Starter
+              link: /docs/modifying-a-starter/
+            - title: Creating a Starter
+              link: /docs/creating-a-starter/
         - title: Styling Your Site
           link: /docs/styling/
           breadcrumbTitle: Styling
@@ -541,6 +541,8 @@
           link: /docs/gatsby-core-philosophy/
         - title: Gatsby Project Structure
           link: /docs/gatsby-project-structure/
+        - title: Plugins, Themes, & Starters
+          link: /docs/plugins-themes-and-starters/
         - title: Overview of the Gatsby Build Process
           link: /docs/overview-of-the-gatsby-build-process/
         - title: Building with Components


### PR DESCRIPTION
Fixed the gatsby-transformer-asciidoc's custom converter example because it was old.

## Description

`asciidoctor` has latest update than `asciidoctor.js`

https://www.npmjs.com/package/asciidoctor
https://www.npmjs.com/package/asciidoctor.js

The following error occurs when using `asciidoctor.js`
```
 ERROR

Error in "/sample/node_modules/gatsby-transformer-asciidoc/gatsby-node.js": Object prototype may only be an Object or null: undefined



  TypeError: Object prototype may only be an Object or null: undefined

  - setPrototypeOf

  - opal.js:450 Object.Opal.allocate_class
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:450:7

  - opal.js:518 Opal.klass
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:518:18

  - opal.js:4919
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:4919:16

  - opal.js:5072 Opal.modules.corelib/error
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:5072:5

  - opal.js:2311 Object.Opal.load
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:2311:7

  - opal.js:2339 constructor.Opal.require
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:2339:17

  - opal.js:5439 Opal.modules.opal/base
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:5439:8

  - opal.js:2311 Object.Opal.load
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:2311:7

  - opal.js:2339 constructor.Opal.require
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:2339:17

  - opal.js:19939
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:19939:8

  - opal.js:19949 Object.<anonymous>
    [sample]/[asciidoctor-opal-runtime]/src/opal.js:19949:3

  - v8-compile-cache.js:178 Module._compile
    [sample]/[v8-compile-cache]/v8-compile-cache.js:178:30

  - loader.js:973 Object.Module._extensions..js
    internal/modules/cjs/loader.js:973:10

  - loader.js:812 Module.load
    internal/modules/cjs/loader.js:812:32

  - loader.js:724 Function.Module._load
    internal/modules/cjs/loader.js:724:14
```